### PR TITLE
Support Windows file paths

### DIFF
--- a/render.js
+++ b/render.js
@@ -27,6 +27,13 @@ module.exports = class DocumentRender{
             nunjucks.configure(swaggerUIPath);
             let res = nunjucks.render("index.njk", {swaggerUIPath: swaggerUIPath, content: content});
             fs.writeFileSync(destFile, res);
+
+            // Turn windows file paths into a URI path:
+            destFile = destFile.replace(/\\/g, "/");
+            if (destFile[0] !== "/") {
+                destFile = "/" + destFile;
+            }
+
             return vscode.Uri.parse('file://' + destFile);
         } catch (error) {
             console.error(error);


### PR DESCRIPTION
On windows, the swagger viewer fails to open with an error message along those lines:
```
Unable to open the file: 'file://c:\Users\bob\.vscode\extensions\openapi-viewer/swagger-ui/index.htm'
```

Indeed the URI requires a path formatted ala Unix.

Once we can use the WHATWG URL: `new URL(destFile).href` will do it (https://github.com/nodejs/node/issues/20080#issuecomment-381686455).
In the mean time the following code does the required transformation.

Thanks for your attention!